### PR TITLE
feat: add kinetic headline, 3d product cards, pattern lab

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { AppComponent } from './app.component';
 import { HomeComponent } from './home/home.component';
 import { ProductsComponent } from './products/products.component';
+import { ProductCard3dComponent } from './products/product-card3d.component';
 import { AboutComponent } from './about/about.component';
 import { HeroCanvasComponent } from './hero-canvas/hero-canvas.component';
 import { CursorThreadComponent } from './cursor-thread/cursor-thread.component';
@@ -18,11 +19,13 @@ import { TiltDirective } from './directives/tilt.directive';
 import { ScrollRevealDirective } from './directives/scroll-reveal.directive';
 import { MagneticDirective } from './directives/magnetic.directive';
 import { ApiService } from './services/api.service';
+import { PatternLabComponent } from './pattern-lab/pattern-lab.component';
 
 const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: 'products', component: ProductsComponent },
   { path: 'about', component: AboutComponent },
+  { path: 'lab', component: PatternLabComponent },
   { path: '**', redirectTo: '' }
 ];
 
@@ -31,6 +34,7 @@ const routes: Routes = [
     AppComponent,
     HomeComponent,
     ProductsComponent,
+    ProductCard3dComponent,
     AboutComponent,
     TiltDirective,
     ScrollRevealDirective,
@@ -40,7 +44,8 @@ const routes: Routes = [
     HorizontalGalleryComponent,
     MagneticDirective,
     YarnTimelineComponent,
-    LoomComponent
+    LoomComponent,
+    PatternLabComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/kinetic-headline/kinetic-headline.component.ts
+++ b/src/app/kinetic-headline/kinetic-headline.component.ts
@@ -1,28 +1,49 @@
-import {AfterViewInit, Component, ElementRef, Input, ViewChild} from '@angular/core';
+import { AfterViewInit, Component, ElementRef, Input, ViewChild } from '@angular/core';
 import gsap from 'gsap';
+import { SettingsService } from '../services/settings.service';
 
 @Component({
-    selector: 'app-kinetic-headline',
-    template: `<h1 class="text-5xl md:text-7xl font-display tracking-tight glow-text inline-block">
-        <span #wrap></span>
-    </h1>`
+  selector: 'app-kinetic-headline',
+  template: `
+    <h1 class="relative inline-block text-5xl md:text-7xl font-display tracking-tight glow-text">
+      <span #filled class="block opacity-0">{{ text }}</span>
+      <svg #svg class="absolute inset-0 w-full h-full overflow-visible" aria-hidden="true">
+        <text #strokeText x="0" y="0" dominant-baseline="hanging" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none" style="font: inherit;">
+          {{ text }}
+        </text>
+      </svg>
+    </h1>
+  `
 })
 export class KineticHeadlineComponent implements AfterViewInit {
-    @Input() text = 'Stichi';
-    @ViewChild('wrap', {static: false}) wrapRef!: ElementRef<HTMLSpanElement>;
+  @Input() text = 'Stichi';
+  @ViewChild('strokeText', { static: false }) strokeRef!: ElementRef<SVGTextElement>;
+  @ViewChild('filled', { static: false }) filledRef!: ElementRef<HTMLSpanElement>;
 
-    constructor(private el: ElementRef) {
+  constructor(private settings: SettingsService) {}
+
+  ngAfterViewInit(): void {
+    const reduce = this.settings.prefersReducedMotion();
+    const strokeEl = this.strokeRef.nativeElement;
+    const filled = this.filledRef.nativeElement;
+
+    const length = strokeEl.getComputedTextLength();
+    strokeEl.style.strokeDasharray = '6 14';
+    strokeEl.style.strokeDashoffset = String(length);
+
+    if (reduce) {
+      strokeEl.style.display = 'none';
+      filled.style.opacity = '1';
+      return;
     }
 
-    ngAfterViewInit(): void {
-        const wrap = this.wrapRef.nativeElement;
-        wrap.innerHTML = this.text
-            .split('')
-            .map(ch => `<span class="inline-block will-change-transform">${ch === ' ' ? '&nbsp;' : ch}</span>`)
-            .join('');
-        const letters = wrap.querySelectorAll('span');
-        gsap.fromTo(letters, {yPercent: 130, rotate: 8, opacity: 0}, {
-            yPercent: 0, rotate: 0, opacity: 1, ease: 'expo.out', duration: 1, stagger: 0.035
-        });
-    }
+    const tl = gsap.timeline();
+    tl.to(strokeEl, {
+      strokeDashoffset: 0,
+      duration: 2,
+      ease: 'power2.out'
+    });
+    tl.to(filled, { opacity: 1, duration: 0.5 }, '-=0.4');
+    tl.to(strokeEl, { opacity: 0, duration: 0.5 }, '<');
+  }
 }

--- a/src/app/pattern-lab/pattern-lab.component.css
+++ b/src/app/pattern-lab/pattern-lab.component.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/pattern-lab/pattern-lab.component.html
+++ b/src/app/pattern-lab/pattern-lab.component.html
@@ -1,0 +1,25 @@
+<section class="container mx-auto py-16 px-6 space-y-8">
+  <h2 class="text-3xl font-bold">Stitch Lab</h2>
+  <form class="flex flex-wrap gap-4 items-end">
+    <label class="flex flex-col">
+      <span class="mb-1">Stitch</span>
+      <select class="border rounded p-2" [(ngModel)]="stitch" name="stitch" (change)="updatePattern()">
+        <option value="moss">Moss</option>
+        <option value="rib">Rib</option>
+        <option value="cable">Cable</option>
+      </select>
+    </label>
+    <label class="flex flex-col">
+      <span class="mb-1">Gauge</span>
+      <input type="number" class="border rounded p-2 w-24" [(ngModel)]="gauge" name="gauge" min="4" max="32" (input)="updatePattern()" />
+    </label>
+    <label class="flex flex-col">
+      <span class="mb-1">Color</span>
+      <input type="color" class="border rounded p-2 w-24" [(ngModel)]="color" name="color" (input)="updatePattern()" />
+    </label>
+  </form>
+  <div class="flex gap-8">
+    <div class="w-32 h-32 border rounded" [style.backgroundImage]="'url(' + patternUrl + ')'" [style.backgroundSize]="gauge * 4 + 'px'"></div>
+    <div class="w-40 h-56 border rounded" [style.backgroundImage]="'url(' + patternUrl + ')'" style="background-size:cover;"></div>
+  </div>
+</section>

--- a/src/app/pattern-lab/pattern-lab.component.ts
+++ b/src/app/pattern-lab/pattern-lab.component.ts
@@ -1,0 +1,81 @@
+import { Component, OnInit } from '@angular/core';
+import { SettingsService } from '../services/settings.service';
+
+@Component({
+  selector: 'app-pattern-lab',
+  templateUrl: './pattern-lab.component.html',
+  styleUrls: ['./pattern-lab.component.css']
+})
+export class PatternLabComponent implements OnInit {
+  stitch = 'moss';
+  gauge = 8; // base pixel size
+  color = '#d53f8c';
+  patternUrl = '';
+  private canvas!: HTMLCanvasElement;
+
+  constructor(private settings: SettingsService) {}
+
+  ngOnInit(): void {
+    const reduce = this.settings.prefersReducedMotion();
+    // currently no animations but read once per conventions
+    this.canvas = document.createElement('canvas');
+    this.updatePattern();
+  }
+
+  updatePattern(): void {
+    const size = this.gauge * 4;
+    const ctx = this.canvas.getContext('2d')!;
+    this.canvas.width = this.canvas.height = size;
+    ctx.clearRect(0, 0, size, size);
+    ctx.fillStyle = this.color;
+    ctx.fillRect(0, 0, size, size);
+
+    switch (this.stitch) {
+      case 'rib':
+        ctx.fillStyle = this.shade(this.color, -20);
+        for (let x = 0; x < size; x += this.gauge * 2) {
+          ctx.fillRect(x, 0, this.gauge, size);
+        }
+        break;
+      case 'cable':
+        ctx.strokeStyle = this.shade(this.color, -30);
+        ctx.lineWidth = this.gauge / 2;
+        for (let x = 0; x < size; x += this.gauge * 2) {
+          ctx.beginPath();
+          ctx.moveTo(x, 0);
+          ctx.bezierCurveTo(x + this.gauge, size / 2, x + this.gauge, size / 2, x + this.gauge * 2, size);
+          ctx.stroke();
+          ctx.beginPath();
+          ctx.moveTo(x + this.gauge, 0);
+          ctx.bezierCurveTo(x, size / 2, x, size / 2, x + this.gauge * 2, size);
+          ctx.stroke();
+        }
+        break;
+      default: // moss
+        for (let y = 0; y < size; y += this.gauge) {
+          for (let x = 0; x < size; x += this.gauge) {
+            ctx.fillStyle = (x / this.gauge + y / this.gauge) % 2 === 0
+              ? this.shade(this.color, -15)
+              : this.shade(this.color, 15);
+            ctx.fillRect(x, y, this.gauge, this.gauge);
+          }
+        }
+    }
+
+    this.patternUrl = this.canvas.toDataURL();
+  }
+
+  private shade(color: string, percent: number): string {
+    const num = parseInt(color.slice(1), 16);
+    const amt = Math.round(2.55 * percent);
+    const R = (num >> 16) + amt;
+    const G = (num >> 8 & 0x00ff) + amt;
+    const B = (num & 0x0000ff) + amt;
+    return '#' + (
+      0x1000000 +
+      (R < 255 ? (R < 1 ? 0 : R) : 255) * 0x10000 +
+      (G < 255 ? (G < 1 ? 0 : G) : 255) * 0x100 +
+      (B < 255 ? (B < 1 ? 0 : B) : 255)
+    ).toString(16).slice(1);
+  }
+}

--- a/src/app/products/product-card3d.component.css
+++ b/src/app/products/product-card3d.component.css
@@ -1,0 +1,6 @@
+:host {
+  display: block;
+}
+canvas {
+  display: block;
+}

--- a/src/app/products/product-card3d.component.html
+++ b/src/app/products/product-card3d.component.html
@@ -1,0 +1,16 @@
+<div class="bg-white rounded-xl shadow-lg overflow-hidden" appTilt>
+  <div class="relative w-full h-60">
+    <canvas *ngIf="!fallback" #canvas class="w-full h-full block"></canvas>
+    <img *ngIf="fallback" [src]="product.image" [alt]="product.name" class="w-full h-full object-cover" />
+  </div>
+  <div class="p-4">
+    <h3 class="text-xl font-semibold mb-2">{{ product.name }}</h3>
+    <p class="text-gray-600 mb-2">{{ product.description }}</p>
+    <div class="flex items-center justify-between">
+      <span class="text-primary font-bold">{{ product.price | currency:'EUR' }}</span>
+      <button (click)="addToCart()" class="bg-primary text-white px-4 py-2 rounded-full hover:bg-opacity-90 transition-colors">
+        Add to Cart
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/products/product-card3d.component.ts
+++ b/src/app/products/product-card3d.component.ts
@@ -1,0 +1,110 @@
+import { AfterViewInit, Component, ElementRef, EventEmitter, Input, OnDestroy, Output, ViewChild } from '@angular/core';
+import { SettingsService } from '../services/settings.service';
+import {
+  Scene,
+  PerspectiveCamera,
+  WebGLRenderer,
+  PlaneGeometry,
+  MeshStandardMaterial,
+  Mesh,
+  DirectionalLight,
+  TextureLoader
+} from 'three';
+
+@Component({
+  selector: 'app-product-card3d',
+  templateUrl: './product-card3d.component.html',
+  styleUrls: ['./product-card3d.component.css']
+})
+export class ProductCard3dComponent implements AfterViewInit, OnDestroy {
+  @Input() product!: any;
+  @Output() add = new EventEmitter<any>();
+  @ViewChild('canvas', { static: false }) canvasRef!: ElementRef<HTMLCanvasElement>;
+
+  fallback = false;
+  private renderer?: WebGLRenderer;
+  private scene?: Scene;
+  private camera?: PerspectiveCamera;
+  private light?: DirectionalLight;
+  private mesh?: Mesh;
+  private reduce = false;
+
+  constructor(private settings: SettingsService, private host: ElementRef<HTMLElement>) {}
+
+  ngAfterViewInit(): void {
+    this.reduce = this.settings.prefersReducedMotion();
+    if (this.reduce || !this.canWebGL()) {
+      this.fallback = true;
+      return;
+    }
+
+    const canvas = this.canvasRef.nativeElement;
+    const rect = this.host.nativeElement.getBoundingClientRect();
+
+    this.renderer = new WebGLRenderer({ canvas, antialias: true, alpha: true });
+    this.renderer.setSize(rect.width, rect.height);
+
+    this.scene = new Scene();
+    this.camera = new PerspectiveCamera(45, rect.width / rect.height, 0.1, 100);
+    this.camera.position.z = 1.5;
+
+    const geometry = new PlaneGeometry(1, 1, 32, 32);
+    const loader = new TextureLoader();
+    const materialOpts: any = { map: loader.load(this.product.image) };
+    if (this.product.normalMap) materialOpts.normalMap = loader.load(this.product.normalMap);
+    if (this.product.depthMap) materialOpts.displacementMap = loader.load(this.product.depthMap);
+    const material = new MeshStandardMaterial(materialOpts);
+
+    this.mesh = new Mesh(geometry, material);
+    this.scene.add(this.mesh);
+
+    this.light = new DirectionalLight(0xffffff, 1);
+    this.light.position.set(0, 0, 1);
+    this.scene.add(this.light);
+
+    const render = () => {
+      if (!this.renderer) return;
+      this.renderer.render(this.scene!, this.camera!);
+      requestAnimationFrame(render);
+    };
+    render();
+
+    this.host.nativeElement.addEventListener('mousemove', this.onMouseMove);
+    window.addEventListener('resize', this.onResize);
+  }
+
+  private onMouseMove = (e: MouseEvent) => {
+    if (!this.light) return;
+    const rect = this.host.nativeElement.getBoundingClientRect();
+    const x = (e.clientX - rect.left) / rect.width * 2 - 1;
+    const y = -((e.clientY - rect.top) / rect.height * 2 - 1);
+    this.light.position.set(x, y, 1);
+  };
+
+  private onResize = () => {
+    if (!this.renderer || !this.camera) return;
+    const rect = this.host.nativeElement.getBoundingClientRect();
+    this.renderer.setSize(rect.width, rect.height);
+    this.camera.aspect = rect.width / rect.height;
+    this.camera.updateProjectionMatrix();
+  };
+
+  addToCart(): void {
+    this.add.emit(this.product);
+  }
+
+  ngOnDestroy(): void {
+    this.host.nativeElement.removeEventListener('mousemove', this.onMouseMove);
+    window.removeEventListener('resize', this.onResize);
+    this.renderer?.dispose();
+  }
+
+  private canWebGL(): boolean {
+    try {
+      const canvas = document.createElement('canvas');
+      return !!(canvas.getContext('webgl') || canvas.getContext('experimental-webgl'));
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/app/products/products.component.html
+++ b/src/app/products/products.component.html
@@ -1,18 +1,6 @@
 <section class="container mx-auto py-20 px-6">
   <h2 class="text-3xl font-bold mb-8 text-center">Our Collection</h2>
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
-    <div *ngFor="let product of products" class="bg-white rounded-xl shadow-lg overflow-hidden transform transition-transform hover:-translate-y-2 hover:shadow-2xl">
-      <img [src]="product.image" [alt]="product.name" class="w-full h-60 object-cover" />
-      <div class="p-4">
-        <h3 class="text-xl font-semibold mb-2">{{ product.name }}</h3>
-        <p class="text-gray-600 mb-2">{{ product.description }}</p>
-        <div class="flex items-center justify-between">
-          <span class="text-primary font-bold">{{ product.price | currency:'EUR' }}</span>
-          <button (click)="addToCart(product)" class="bg-primary text-white px-4 py-2 rounded-full hover:bg-opacity-90 transition-colors">
-            Add to Cart
-          </button>
-        </div>
-      </div>
-    </div>
+    <app-product-card3d *ngFor="let product of products" [product]="product" (add)="addToCart($event)"></app-product-card3d>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- animate headline using SVG stroke dashes that crossfade to filled text and respect reduced motion
- introduce Three.js powered product cards with light-following hover and CSS-only fallback
- add Stitch Lab route for procedurally generated knit patterns

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ENOENT: tsconfig.spec.json)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689740e637d0832ca521b22092341987