### PR TITLE
feat: add interactive mend, story and palette sections

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -15,6 +15,9 @@ import { KineticHeadlineComponent } from './kinetic-headline/kinetic-headline.co
 import { HorizontalGalleryComponent } from './horizontal-gallery/horizontal-gallery.component';
 import { YarnTimelineComponent } from './yarn-timeline/yarn-timeline.component';
 import { LoomComponent } from './loom/loom.component';
+import { StitchStoryComponent } from './stitch-story/stitch-story.component';
+import { PaletteSpoolsComponent } from './palette-spools/palette-spools.component';
+import { MendStoriesComponent } from './mend-stories/mend-stories.component';
 import { TiltDirective } from './directives/tilt.directive';
 import { ScrollRevealDirective } from './directives/scroll-reveal.directive';
 import { MagneticDirective } from './directives/magnetic.directive';
@@ -45,6 +48,9 @@ const routes: Routes = [
     MagneticDirective,
     YarnTimelineComponent,
     LoomComponent,
+    StitchStoryComponent,
+    PaletteSpoolsComponent,
+    MendStoriesComponent,
     PatternLabComponent
   ],
   imports: [

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -41,6 +41,21 @@
     <app-loom></app-loom>
   </section>
 
+  <!-- STITCH STORY: image sequence -->
+  <section #journeySection class="section bg-white">
+    <app-stitch-story></app-stitch-story>
+  </section>
+
+  <!-- PALETTE SPOOLS -->
+  <section #journeySection class="section bg-neutral-50">
+    <app-palette-spools (select)="colorPicked($event)"></app-palette-spools>
+  </section>
+
+  <!-- MEND STORIES -->
+  <section #journeySection class="section bg-white">
+    <app-mend-stories></app-mend-stories>
+  </section>
+
   <!-- SUSTAINABILITY: parallax backdrop -->
   <section #journeySection class="section text-center text-white">
     <div class="absolute inset-0 -z-10">

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -88,6 +88,10 @@ export class HomeComponent implements OnInit, AfterViewInit {
     }
   }
 
+  colorPicked(hex: string) {
+    console.log('Selected color', hex);
+  }
+
   ngAfterViewInit(): void {
     this.sections.forEach((s) => this.journey.registerSection(s.nativeElement));
   }

--- a/src/app/mend-stories/mend-stories.component.css
+++ b/src/app/mend-stories/mend-stories.component.css
@@ -1,0 +1,5 @@
+:host { @apply block h-full; }
+.stitch { @apply absolute w-4 h-4 -ml-2 -mt-2 rounded-full bg-secondary text-white text-[10px] flex items-center justify-center focus:outline-none focus:ring; }
+.overlay { @apply absolute inset-0 bg-black/50 flex items-center justify-center; }
+.card { @apply bg-white p-4 rounded relative max-w-xs; }
+.close { @apply absolute top-1 right-1 text-sm; }

--- a/src/app/mend-stories/mend-stories.component.html
+++ b/src/app/mend-stories/mend-stories.component.html
@@ -1,0 +1,18 @@
+<div #host class="relative h-full flex items-center justify-center">
+  <img src="https://via.placeholder.com/600x400?text=Garment" alt="Garment with repair marks" class="max-w-full" />
+
+  <ng-container *ngFor="let m of mends">
+    <button class="stitch" [style.left.%]="m.x" [style.top.%]="m.y"
+            (click)="open(m)" (focus)="open(m)" [attr.aria-label]="m.title">
+      ✚
+    </button>
+  </ng-container>
+
+  <div *ngIf="active" class="overlay" (click)="close()">
+    <div class="card" (click)="$event.stopPropagation()" role="dialog" aria-modal="true">
+      <button class="close" (click)="close()" aria-label="Close">×</button>
+      <h4 class="font-bold mb-2">{{active.title}}</h4>
+      <p class="text-sm">{{active.story}}</p>
+    </div>
+  </div>
+</div>

--- a/src/app/mend-stories/mend-stories.component.ts
+++ b/src/app/mend-stories/mend-stories.component.ts
@@ -1,0 +1,54 @@
+import { AfterViewInit, Component, ElementRef, HostListener, ViewChild } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { SettingsService } from '../services/settings.service';
+import { JourneyService } from '../services/journey.service';
+
+interface Mend {
+  id: number;
+  x: number;
+  y: number;
+  title: string;
+  story: string;
+}
+
+@Component({
+  selector: 'app-mend-stories',
+  templateUrl: './mend-stories.component.html',
+  styleUrls: ['./mend-stories.component.css']
+})
+export class MendStoriesComponent implements AfterViewInit {
+  @ViewChild('host', { static: true }) host!: ElementRef<HTMLElement>;
+
+  mends: Mend[] = [];
+  active?: Mend;
+  reduce = false;
+
+  constructor(
+    private http: HttpClient,
+    private settings: SettingsService,
+    private journey: JourneyService
+  ) {}
+
+  ngAfterViewInit(): void {
+    const el = this.host.nativeElement;
+    this.journey.registerSection(el);
+    this.reduce = this.settings.prefersReducedMotion();
+
+    this.http.get<Mend[]>('assets/mends/mends.json').subscribe((data) => {
+      this.mends = data;
+    });
+  }
+
+  open(m: Mend) {
+    this.active = m;
+  }
+
+  close() {
+    this.active = undefined;
+  }
+
+  @HostListener('document:keydown.escape')
+  handleEscape() {
+    this.close();
+  }
+}

--- a/src/app/palette-spools/palette-spools.component.css
+++ b/src/app/palette-spools/palette-spools.component.css
@@ -1,0 +1,7 @@
+:host { @apply block h-full; }
+.spool { @apply relative w-20 h-32 cursor-grab; transform-style: preserve-3d; }
+.spool:active { cursor: grabbing; }
+.thread { @apply absolute inset-4 rounded-full; }
+.spool::before, .spool::after { content: ''; position: absolute; left:0; width:100%; height:16px; background:#d4d4d4; border-radius:50%; }
+.spool::before { top:-8px; }
+.spool::after { bottom:-8px; }

--- a/src/app/palette-spools/palette-spools.component.html
+++ b/src/app/palette-spools/palette-spools.component.html
@@ -1,0 +1,11 @@
+<div #host class="h-full flex items-center justify-center gap-8 select-none" style="perspective:600px;">
+  <div *ngFor="let sp of spools"
+       class="spool"
+       (pointerdown)="onPointerDown(sp,$event)"
+       (pointermove)="onPointerMove($event)"
+       (pointerup)="onPointerUp($event)"
+       (pointercancel)="onPointerUp($event)"
+       [style.transform]="'rotateY(' + sp.angle + 'deg)'">
+    <div class="thread" [style.background]="getGradient(sp.hue)"></div>
+  </div>
+</div>

--- a/src/app/palette-spools/palette-spools.component.ts
+++ b/src/app/palette-spools/palette-spools.component.ts
@@ -1,0 +1,86 @@
+import { AfterViewInit, Component, ElementRef, EventEmitter, Output, ViewChild } from '@angular/core';
+import { SettingsService } from '../services/settings.service';
+import { JourneyService } from '../services/journey.service';
+
+interface Spool {
+  hue: number;
+  angle: number;
+}
+
+@Component({
+  selector: 'app-palette-spools',
+  templateUrl: './palette-spools.component.html',
+  styleUrls: ['./palette-spools.component.css']
+})
+export class PaletteSpoolsComponent implements AfterViewInit {
+  @ViewChild('host', { static: true }) host!: ElementRef<HTMLElement>;
+  @Output() select = new EventEmitter<string>();
+
+  spools: Spool[] = [
+    { hue: 0, angle: 0 },
+    { hue: 120, angle: 0 },
+    { hue: 240, angle: 0 }
+  ];
+
+  reduce = false;
+  private active?: Spool;
+  private startX = 0;
+
+  constructor(private settings: SettingsService, private journey: JourneyService) {}
+
+  ngAfterViewInit(): void {
+    this.journey.registerSection(this.host.nativeElement);
+    this.reduce = this.settings.prefersReducedMotion();
+  }
+
+  onPointerDown(sp: Spool, e: PointerEvent) {
+    this.active = sp;
+    this.startX = e.clientX;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }
+
+  onPointerMove(e: PointerEvent) {
+    if (!this.active) return;
+    const delta = e.clientX - this.startX;
+    this.active.angle = this.reduce ? delta * 0.2 : delta;
+  }
+
+  onPointerUp(e: PointerEvent) {
+    if (!this.active) return;
+    const hue = (this.active.hue + this.active.angle) % 360;
+    const hex = this.hslToHex(hue, 70, 50);
+    this.select.emit(hex);
+    this.active.angle = 0;
+    this.active = undefined;
+  }
+
+  getGradient(hue: number) {
+    return `linear-gradient(90deg, hsl(${hue},70%,50%), hsl(${(hue + 60) % 360},70%,50%))`;
+  }
+
+  private hslToHex(h: number, s: number, l: number): string {
+    h /= 360;
+    s /= 100;
+    l /= 100;
+    let r: number, g: number, b: number;
+    if (s === 0) {
+      r = g = b = l;
+    } else {
+      const hue2rgb = (p: number, q: number, t: number) => {
+        if (t < 0) t += 1;
+        if (t > 1) t -= 1;
+        if (t < 1 / 6) return p + (q - p) * 6 * t;
+        if (t < 1 / 2) return q;
+        if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+        return p;
+      };
+      const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+      const p = 2 * l - q;
+      r = hue2rgb(p, q, h + 1 / 3);
+      g = hue2rgb(p, q, h);
+      b = hue2rgb(p, q, h - 1 / 3);
+    }
+    const toHex = (x: number) => Math.round(x * 255).toString(16).padStart(2, '0');
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+  }
+}

--- a/src/app/stitch-story/stitch-story.component.css
+++ b/src/app/stitch-story/stitch-story.component.css
@@ -1,0 +1,1 @@
+:host { @apply block; }

--- a/src/app/stitch-story/stitch-story.component.html
+++ b/src/app/stitch-story/stitch-story.component.html
@@ -1,0 +1,14 @@
+<div #host class="relative h-[200vh]">
+  <div class="sticky top-0 h-screen w-full">
+    <ng-container *ngIf="!reduce; else reduceTpl">
+      <img [src]="frames[current]" class="w-full h-full object-cover" alt="story frame" />
+    </ng-container>
+    <ng-template #reduceTpl>
+      <div class="relative w-full h-full">
+        <img *ngFor="let src of [frames[0], frames[Math.floor(frames.length/2)], frames[frames.length-1]]; let i = index"
+             [src]="src" class="absolute inset-0 w-full h-full object-cover transition-opacity duration-700"
+             [style.opacity]="currentReduce === i ? 1 : 0" alt="story frame" />
+      </div>
+    </ng-template>
+  </div>
+</div>

--- a/src/app/stitch-story/stitch-story.component.ts
+++ b/src/app/stitch-story/stitch-story.component.ts
@@ -1,0 +1,59 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
+import { LenisService } from '../services/lenis.service';
+import { SettingsService } from '../services/settings.service';
+import { JourneyService } from '../services/journey.service';
+
+@Component({
+  selector: 'app-stitch-story',
+  templateUrl: './stitch-story.component.html',
+  styleUrls: ['./stitch-story.component.css']
+})
+export class StitchStoryComponent implements AfterViewInit, OnDestroy {
+  @ViewChild('host', { static: true }) host!: ElementRef<HTMLElement>;
+
+  frames: string[] = [];
+  current = 0;
+  currentReduce = 0;
+  reduce = false;
+  private offScroll?: () => void;
+
+  constructor(
+    private lenis: LenisService,
+    private settings: SettingsService,
+    private journey: JourneyService
+  ) {}
+
+  ngAfterViewInit(): void {
+    const el = this.host.nativeElement;
+    this.journey.registerSection(el);
+    this.reduce = this.settings.prefersReducedMotion();
+
+    const total = 10;
+    for (let i = 1; i <= total; i++) {
+      const src = `assets/story/sequence_${i.toString().padStart(4, '0')}.jpg`;
+      this.frames.push(src);
+      const img = new Image();
+      img.src = src;
+    }
+
+    const lenisInstance = this.lenis.instance;
+    if (!lenisInstance) return;
+    const update = ({ scroll }: any) => {
+      const rect = el.getBoundingClientRect();
+      const totalScroll = el.offsetHeight - window.innerHeight;
+      const top = -rect.top;
+      const progress = Math.min(Math.max(top / totalScroll, 0), 1);
+      if (this.reduce) {
+        this.currentReduce = Math.round(progress * 2);
+      } else {
+        this.current = Math.round(progress * (this.frames.length - 1));
+      }
+    };
+    lenisInstance.on('scroll', update);
+    this.offScroll = () => lenisInstance.off('scroll', update);
+  }
+
+  ngOnDestroy(): void {
+    this.offScroll?.();
+  }
+}

--- a/src/assets/mends/mends.json
+++ b/src/assets/mends/mends.json
@@ -1,0 +1,4 @@
+[
+  { "id": 1, "x": 30, "y": 40, "title": "Elbow Patch", "story": "A small patch reinforces the sleeve." },
+  { "id": 2, "x": 65, "y": 70, "title": "Sashiko Stitch", "story": "Decorative mend keeps the fabric strong." }
+]

--- a/src/assets/story/sequence_0001.jpg
+++ b/src/assets/story/sequence_0001.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/src/assets/story/sequence_0002.jpg
+++ b/src/assets/story/sequence_0002.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/src/assets/story/sequence_0003.jpg
+++ b/src/assets/story/sequence_0003.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/src/assets/story/sequence_0004.jpg
+++ b/src/assets/story/sequence_0004.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/src/assets/story/sequence_0005.jpg
+++ b/src/assets/story/sequence_0005.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/src/assets/story/sequence_0006.jpg
+++ b/src/assets/story/sequence_0006.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/src/assets/story/sequence_0007.jpg
+++ b/src/assets/story/sequence_0007.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/src/assets/story/sequence_0008.jpg
+++ b/src/assets/story/sequence_0008.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/src/assets/story/sequence_0009.jpg
+++ b/src/assets/story/sequence_0009.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/src/assets/story/sequence_0010.jpg
+++ b/src/assets/story/sequence_0010.jpg
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Summary
- add MendStories overlay with keyboard-accessible repair cards
- introduce StitchStory scroll-pinned image sequence with reduced-motion fallback
- create PaletteSpools draggable color selector emitting hex values
- wire new sections into home journey and assets

## Testing
- `npm test` *(fails: tsconfig.spec.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897440bd2f0832c9b2640582132fa55