### PR TITLE
feat: add row counter and soft haptics

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,6 +24,7 @@ import { MagneticDirective } from './directives/magnetic.directive';
 import { ApiService } from './services/api.service';
 import { PatternLabComponent } from './pattern-lab/pattern-lab.component';
 import { FabricMicroscopeComponent } from './fabric-microscope/fabric-microscope.component';
+import { RowCounterComponent } from './row-counter/row-counter.component';
 
 const routes: Routes = [
   { path: '', component: HomeComponent },
@@ -53,7 +54,8 @@ const routes: Routes = [
     PaletteSpoolsComponent,
     MendStoriesComponent,
     PatternLabComponent,
-    FabricMicroscopeComponent
+    FabricMicroscopeComponent,
+    RowCounterComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -81,4 +81,5 @@
       </form>
     </div>
   </section>
+  <app-row-counter></app-row-counter>
 </div>

--- a/src/app/row-counter/row-counter.component.css
+++ b/src/app/row-counter/row-counter.component.css
@@ -1,0 +1,6 @@
+:host {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 50;
+}

--- a/src/app/row-counter/row-counter.component.html
+++ b/src/app/row-counter/row-counter.component.html
@@ -1,0 +1,3 @@
+<div *ngIf="total > 0" class="w-12 h-12 rounded-full bg-black/60 text-white flex items-center justify-center text-sm" role="status" aria-live="polite" [attr.aria-label]="label">
+  {{ index }}/{{ total }}
+</div>

--- a/src/app/row-counter/row-counter.component.ts
+++ b/src/app/row-counter/row-counter.component.ts
@@ -1,0 +1,35 @@
+import { Component, AfterViewInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { JourneyService } from '../services/journey.service';
+
+@Component({
+  selector: 'app-row-counter',
+  templateUrl: './row-counter.component.html',
+  styleUrls: ['./row-counter.component.css']
+})
+export class RowCounterComponent implements AfterViewInit, OnDestroy {
+  index = 1;
+  total = 0;
+  private sub?: Subscription;
+
+  constructor(private journey: JourneyService) {}
+
+  ngAfterViewInit(): void {
+    // ensure sections have registered before reading
+    setTimeout(() => (this.total = this.journey.totalSections()));
+    this.sub = this.journey.index$.subscribe((i) => {
+      this.index = i + 1;
+      // keep total in sync in case sections change dynamically
+      this.total = this.journey.totalSections();
+    });
+  }
+
+  get label(): string {
+    return `Section ${this.index} of ${this.total}`;
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
+}
+

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { SettingsService } from './settings.service';
 import { Observable, of, throwError } from 'rxjs';
 import { delay } from 'rxjs/operators';
 
@@ -8,6 +9,11 @@ import { delay } from 'rxjs/operators';
  */
 @Injectable({ providedIn: 'root' })
 export class ApiService {
+  private reduce = false;
+
+  constructor(private settings: SettingsService) {
+    this.reduce = this.settings.prefersReducedMotion();
+  }
   /**
    * Simulates adding a product to the cart.
    * @param productId The product identifier
@@ -16,6 +22,9 @@ export class ApiService {
   addToCart(productId: number): Observable<void> {
     if (productId == null) {
       return throwError(() => new Error('Invalid product id'));
+    }
+    if (!this.reduce) {
+      navigator.vibrate?.(12);
     }
     return of(void 0).pipe(delay(250));
   }


### PR DESCRIPTION
## Summary
- display sticky row counter showing current section in journey
- vibrate on add-to-cart when motion isn't reduced

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ENOENT tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_e_689749e838f4832c8dcd220c3351fab4