### PR TITLE
refactor: simplify hero and counter

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,16 +1,10 @@
 <div>
   <!-- HERO: WebGL constellation + kinetic headline -->
-  <section #journeySection class="section relative text-center text-white">
+  <section class="section relative text-center text-white">
     <app-hero-canvas class="absolute inset-0 -z-10"></app-hero-canvas>
-    <div class="relative z-10 space-y-8">
+    <div class="relative z-10">
       <app-kinetic-headline text="Stichi — handmade, cosmic, yours."></app-kinetic-headline>
-      <button (click)="scrollToSection('section-collection')">
-        <div appTilt appMagnetic class="px-8 py-4 rounded-full bg-white/10 ring-1 ring-white/40 backdrop-blur hover:scale-[1.03] transition">
-          Start Exploring
-        </div>
-      </button>
     </div>
-    <div class="absolute inset-x-0 bottom-10 text-xs opacity-70">scroll • discover</div>
   </section>
 
   <!-- PHILOSOPHY: reveal as you scroll -->

--- a/src/app/row-counter/row-counter.component.html
+++ b/src/app/row-counter/row-counter.component.html
@@ -1,3 +1,3 @@
-<div *ngIf="total > 0" class="w-12 h-12 rounded-full bg-black/60 text-white flex items-center justify-center text-sm" role="status" aria-live="polite" [attr.aria-label]="label">
+<div *ngIf="total > 0 && index > 0" class="w-12 h-12 rounded-full bg-black/60 text-white flex items-center justify-center text-sm" role="status" aria-live="polite" [attr.aria-label]="label">
   {{ index }}/{{ total }}
 </div>


### PR DESCRIPTION
## Summary
- Remove duplicate CTA and scroll hint from hero, and exclude it from journey tracking
- Hide row counter on hero by requiring index > 0

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Error: ENOENT tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_e_68988bd3f85c832caa870acd7f7b8e05